### PR TITLE
Updated Help PR

### DIFF
--- a/src/commands.py
+++ b/src/commands.py
@@ -23,8 +23,9 @@ class command_on_message(BotFunction):
     async def action(self, _):
         raise NotImplementedError(f'{self.__class__.__name__} failed to implement action.')
 
-    def helptxt(self):
-        raise NotImplementedError(f'{self.__class__.__name__} failed to implement helptxt.')
+    @classmethod
+    def helptxt(cls):
+        raise NotImplementedError(f'{cls.__name__} failed to implement helptxt.')
 
 
 class catfact(command_on_message):
@@ -39,7 +40,8 @@ class catfact(command_on_message):
     async def action(self, message, *args, **kwargs):
         return message_data(message.channel, get_catfact())
 
-    def helptxt(self):
+    @classmethod
+    def helptxt(cls):
         return "$catfact \nGets random catfact"
   
 class debug(command_on_message):
@@ -69,7 +71,8 @@ class debug(command_on_message):
             self.bot.debug = False
             await message.channel.send('Debug mode off')
 
-    def helptxt(self):
+    @classmethod
+    def helptxt(cls):
         return None # "$debug \nActivates debug mode"
 
 class sigkill(command_on_message):
@@ -87,7 +90,8 @@ class sigkill(command_on_message):
       await message.channel.send('Killing bot processes...')
       exit()
 
-    def helptxt(self):
+    @classmethod
+    def helptxt(cls):
         return None # "$debug \nKills bot processes when in debug mode"
 
 
@@ -122,7 +126,8 @@ class register(command_on_message):
             return message_data(message.channel, "User already registered")
         return message_data(message.channel, "User registered")
 
-    def helptxt(self):
+    @classmethod
+    def helptxt(cls):
         return "$register \nRegisters a user in the database"
 
 
@@ -149,7 +154,8 @@ class resetregister(command_on_message):
         insert_member(conn, self.bot, user)
         return message_data(message.channel, "User registration reset")
 
-    def helptxt(self):
+    @classmethod
+    def helptxt(cls):
         return "$resetregister \nResets the registration in the database in case of bugs"
 
 
@@ -180,7 +186,8 @@ class kickme(command_on_message):
         await message.author.send("See you later!")
         return
 
-    def helptxt(self):
+    @classmethod
+    def helptxt(cls):
         return "$kickme \nKicks an unregistered user (?)"
 
 
@@ -232,7 +239,8 @@ class nickname(command_on_message):
         await self.nickname_request(message, user, nickname)
         return
 
-    def helptxt(self):
+    @classmethod
+    def helptxt(cls):
         return "$nickname [nickname] \nRequests to change nickname to [nickname]. Requires admin approval."
 
     
@@ -261,7 +269,8 @@ class send(command_on_message):
                 args=[message]
             )
 
-    def helptxt(self):
+    @classmethod
+    def helptxt(cls):
         return None # "$send [channel] [message] \nSends [message] to [channel]. Must be a channel ping."
 
 class choose(command_on_message):
@@ -289,7 +298,8 @@ class choose(command_on_message):
                 "color": 53380}
         )
 
-    def helptxt(self):
+    @classmethod
+    def helptxt(cls):
         return "$choose choice1; choice2[; choice3; ...] \nChooses an option from the provided list."
 
 class help(command_on_message):
@@ -336,7 +346,8 @@ class help(command_on_message):
             "fields": fields
         })
 
-    def helptxt(self):
+    @classmethod
+    def helptxt(cls):
         return "$help [command] \nDisplays description of the provided command. If none is provided, displays description for all commands."
 
 class menu(command_on_message):
@@ -561,5 +572,6 @@ class menu(command_on_message):
         await Machine.create(initial_state, message, initial_message='Typing...', message_to_edit=message_to_replace, timeout=20)
         return None
 
-    def helptxt(self):
+    @classmethod
+    def helptxt(cls):
         return "$menu [dining commons] [mealtime] \nDisplays an interactable Embed showing the menu for the mealtime of the dining commons."

--- a/src/commands.py
+++ b/src/commands.py
@@ -39,7 +39,7 @@ class catfact(command_on_message):
     async def action(self, message, *args, **kwargs):
         return message_data(message.channel, get_catfact())
 
-    def helptxt(_):
+    def helptxt(self):
         return "$catfact \nGets random catfact"
   
 class debug(command_on_message):
@@ -69,7 +69,7 @@ class debug(command_on_message):
             self.bot.debug = False
             await message.channel.send('Debug mode off')
 
-    def helptxt(_):
+    def helptxt(self):
         return None # "$debug \nActivates debug mode"
 
 class sigkill(command_on_message):
@@ -87,7 +87,7 @@ class sigkill(command_on_message):
       await message.channel.send('Killing bot processes...')
       exit()
 
-    def helptxt(_):
+    def helptxt(self):
         return None # "$debug \nKills bot processes when in debug mode"
 
 
@@ -122,7 +122,7 @@ class register(command_on_message):
             return message_data(message.channel, "User already registered")
         return message_data(message.channel, "User registered")
 
-    def helptxt(_):
+    def helptxt(self):
         return "$register \nRegisters a user in the database"
 
 
@@ -149,7 +149,7 @@ class resetregister(command_on_message):
         insert_member(conn, self.bot, user)
         return message_data(message.channel, "User registration reset")
 
-    def helptxt(_):
+    def helptxt(self):
         return "$resetregister \nResets the registration in the database in case of bugs"
 
 
@@ -180,7 +180,7 @@ class kickme(command_on_message):
         await message.author.send("See you later!")
         return
 
-    def helptxt(_):
+    def helptxt(self):
         return "$kickme \nKicks an unregistered user (?)"
 
 
@@ -232,7 +232,7 @@ class nickname(command_on_message):
         await self.nickname_request(message, user, nickname)
         return
 
-    def helptxt(_):
+    def helptxt(self):
         return "$nickname [nickname] \nRequests to change nickname to [nickname]. Requires admin approval."
 
     
@@ -261,7 +261,7 @@ class send(command_on_message):
                 args=[message]
             )
 
-    def helptxt(_):
+    def helptxt(self):
         return None # "$send [channel] [message] \nSends [message] to [channel]. Must be a channel ping."
 
 class choose(command_on_message):
@@ -289,7 +289,7 @@ class choose(command_on_message):
                 "color": 53380}
         )
 
-    def helptxt(_):
+    def helptxt(self):
         return "$choose choice1; choice2[; choice3; ...] \nChooses an option from the provided list."
 
 class help(command_on_message):
@@ -336,7 +336,7 @@ class help(command_on_message):
             "fields": fields
         })
 
-    def helptxt(_):
+    def helptxt(self):
         return "$help [command] \nDisplays description of the provided command. If none is provided, displays description for all commands."
 
 class menu(command_on_message):
@@ -561,5 +561,5 @@ class menu(command_on_message):
         await Machine.create(initial_state, message, initial_message='Typing...', message_to_edit=message_to_replace, timeout=20)
         return None
 
-    def helptxt(_):
+    def helptxt(self):
         return "$menu [dining commons] [mealtime] \nDisplays an interactable Embed showing the menu for the mealtime of the dining commons."

--- a/src/commands.py
+++ b/src/commands.py
@@ -20,12 +20,11 @@ class command_on_message(BotFunction):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    async def action(self, message):
-        raise NotImplementedError
+    async def action(self, _):
+        raise NotImplementedError(f'{self.__class__.__name__} failed to implement action.')
 
-    @staticmethod
-    def helptxt():
-        raise NotImplementedError
+    def helptxt(self):
+        raise NotImplementedError(f'{self.__class__.__name__} failed to implement helptxt.')
 
 
 class catfact(command_on_message):
@@ -40,8 +39,7 @@ class catfact(command_on_message):
     async def action(self, message, *args, **kwargs):
         return message_data(message.channel, get_catfact())
 
-    @staticmethod
-    def helptxt():
+    def helptxt(_):
         return "$catfact \nGets random catfact"
   
 class debug(command_on_message):
@@ -71,9 +69,8 @@ class debug(command_on_message):
             self.bot.debug = False
             await message.channel.send('Debug mode off')
 
-    @staticmethod
-    def helptxt():
-        return "$debug \nActivates debug mode"
+    def helptxt(_):
+        return None # "$debug \nActivates debug mode"
 
 class sigkill(command_on_message):
     """
@@ -90,9 +87,8 @@ class sigkill(command_on_message):
       await message.channel.send('Killing bot processes...')
       exit()
 
-    @staticmethod
-    def helptxt():
-        return "$debug \nKills bot processes when in debug mode"
+    def helptxt(_):
+        return None # "$debug \nKills bot processes when in debug mode"
 
 
 class register(command_on_message):
@@ -126,8 +122,7 @@ class register(command_on_message):
             return message_data(message.channel, "User already registered")
         return message_data(message.channel, "User registered")
 
-    @staticmethod
-    def helptxt():
+    def helptxt(_):
         return "$register \nRegisters a user in the database"
 
 
@@ -154,8 +149,7 @@ class resetregister(command_on_message):
         insert_member(conn, self.bot, user)
         return message_data(message.channel, "User registration reset")
 
-    @staticmethod
-    def helptxt():
+    def helptxt(_):
         return "$resetregister \nResets the registration in the database in case of bugs"
 
 
@@ -186,8 +180,7 @@ class kickme(command_on_message):
         await message.author.send("See you later!")
         return
 
-    @staticmethod
-    def helptxt():
+    def helptxt(_):
         return "$kickme \nKicks an unregistered user (?)"
 
 
@@ -239,8 +232,7 @@ class nickname(command_on_message):
         await self.nickname_request(message, user, nickname)
         return
 
-    @staticmethod
-    def helptxt():
+    def helptxt(_):
         return "$nickname [nickname] \nRequests to change nickname to [nickname]. Requires admin approval."
 
     
@@ -269,9 +261,8 @@ class send(command_on_message):
                 args=[message]
             )
 
-    @staticmethod
-    def helptxt():
-        return "$send [channel] [message] \nSends [message] to [channel]. Must be a channel ping."
+    def helptxt(_):
+        return None # "$send [channel] [message] \nSends [message] to [channel]. Must be a channel ping."
 
 class choose(command_on_message):
     """
@@ -298,21 +289,23 @@ class choose(command_on_message):
                 "color": 53380}
         )
 
-    @staticmethod
-    def helptxt():
+    def helptxt(_):
         return "$choose choice1; choice2[; choice3; ...] \nChooses an option from the provided list."
 
 class help(command_on_message):
     """
     $help [command]
 
-    Displays description of provided command. If no command is provided, displays all commands
+    Displays description of provided command. If no command is provided, displays all commands.
+    If a command should not be displayed in the embed, have it return None.
     """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.commands_list = {}
         for cmd in command_on_message.__subclasses__():
-            self.commands_list[cmd.__name__] = cmd.helptxt()
+            helptxt = cmd.helptxt()
+            if helptxt is not None:
+                self.commands_list[cmd.__name__] = helptxt
 
     async def action(self, message):
         fields = []
@@ -343,8 +336,7 @@ class help(command_on_message):
             "fields": fields
         })
 
-    @staticmethod
-    def helptxt():
+    def helptxt(_):
         return "$help [command] \nDisplays description of the provided command. If none is provided, displays description for all commands."
 
 class menu(command_on_message):
@@ -569,6 +561,5 @@ class menu(command_on_message):
         await Machine.create(initial_state, message, initial_message='Typing...', message_to_edit=message_to_replace, timeout=20)
         return None
 
-    @staticmethod
-    def helptxt():
+    def helptxt(_):
         return "$menu [dining commons] [mealtime] \nDisplays an interactable Embed showing the menu for the mealtime of the dining commons."


### PR DESCRIPTION
I've changed the help function slightly. It now allows for commands to opt-out of having a help text for public display by returning None. This is intended for commands that can only be used by moderators.

I also removed the static method decorator in order for its 'NotImplementedError' to provide some relevant information (what class caused the error).